### PR TITLE
Added left out "Sharpen x 0xfactor"

### DIFF
--- a/deepfry.sh
+++ b/deepfry.sh
@@ -31,7 +31,7 @@ for (( i = 1; i <= $iterations; i++ )); do
 echo -n $i'-'
     
 # Random option 
-operation=$((0 + $RANDOM % 6))
+operation=$((0 + $RANDOM % 7))
   
 # Modulate x factor
 if [[ $operation = "0" ]]; then

--- a/deepfry.sh
+++ b/deepfry.sh
@@ -89,7 +89,7 @@ then
 # Sharpen x 0xfactor  
 else
 		factor=$((3 + $RANDOM % 10))
-    	command='wrkn.jpg -sharpen 0x'$factor' wrkn.jpg'
+    	command='convert wrkn.jpg -sharpen 0x'$factor' wrkn.jpg'
     	echo $command
 		$command
 fi


### PR DESCRIPTION
I am no bash expert but it looks to me like the "Sharpen x 0xfactor" operation has been left out. In addition there was a small bug in the "Sharpen x 0xfactor" operation that I'm guessing was never caught because the code was never run.

Note that I have not been able to test these fixes myself.

I might also be wrong in the assumption that this "Sharpen x 0xfactor" was meant to be included among the possible operations. If not then this dead code should probably be removed.